### PR TITLE
Fix UI layout in Scan component

### DIFF
--- a/liff/src/app/scan/page.tsx
+++ b/liff/src/app/scan/page.tsx
@@ -22,11 +22,11 @@ export default function Scan() {
   return (
     <main className="m-4">
       <h1 className="text-center text-3xl font-semibold">スキャン</h1>
-      <div className="flex w-full h-full justify-center items-center">
+      <div className="flex flex-col w-full h-full justify-center items-center">
         {isSaned ? (
           <>
             <p className="text-center text-2xl">スキャンが完了しました</p>
-            <div className="flex flex-col justify-center items-end gap-2">
+            <div className="flex flex-col justify-center items-left gap-2">
               <h2 className="text-xl">あいことば</h2>
               <p className="text-center text-2xl">{keyword}</p>
             </div>


### PR DESCRIPTION
This pull request fixes the UI layout in the Scan component by updating the flexbox properties. Now, the elements are aligned correctly and the keyword is displayed on the left side instead of the right side.